### PR TITLE
Update composer.json with new swiftmailer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,9 +81,6 @@
             "drupal/search_api": {
                 "Ensure field definition allowed values callbacks are used for field filter callbacks": "https://www.drupal.org/files/issues/2020-06-03/2949022-12--views_filter_options_callback.patch"
             },
-            "drupal/swiftmailer": {
-                "Fix missing filter_format after update to beta2": "https://www.drupal.org/files/issues/2018-03-26/2948607-fix-filter-format-1.patch"
-            },
             "drupal/block_field": {
                 "Add pre-render hooks to be able to alter content": "https://www.drupal.org/files/issues/2018-06-11/block_field-add-proper-alter-hooks-for-field-rendering-2978883-2.patch"
             },
@@ -163,7 +160,7 @@
         "drupal/shariff": "1.5",
         "drupal/social_api": "1.1",
         "drupal/social_auth": "1.0",
-        "drupal/swiftmailer" : "1.0-beta2",
+        "drupal/swiftmailer" : "2.0-beta1",
         "drupal/select2": "1.8",
         "drupal/token": "1.5",
         "drupal/update_helper": "1.3",
@@ -183,7 +180,7 @@
         "php-http/message": "^1.7",
         "zoonman/linkedin-api-php-client": "dev-master#d06531c48d5efc8aaf7dc074a5320f5ba3f906c9",
         "abraham/twitteroauth": "^0.7.4",
-        "swiftmailer/swiftmailer" : "v5.4.12",
+        "swiftmailer/swiftmailer" : "6.2.4",
         "bower-asset/waves": "0.7.6",
         "bower-asset/timepicker": "~1.11.14",
         "bower-asset/tablesaw": "~3.1.0",


### PR DESCRIPTION
## Problem
drupal/sendgrid_integration could not be installed with the old version of swiftmailer.

## Solution
• Removed the patch for the drupal/swiftmailer 1.0-beta2.
• Updated to drupal/swiftmailer 2.0-beta1 and swiftmailer/swiftmailer:6.2.4

## Issue tracker
https://www.drupal.org/project/social/issues/3188183

## How to test
Run composer and confirm new versions in composer.lock.

## Screenshots
N/A

## Release notes
Updated to drupal/swiftmailer:6.2.4

## Change Record
N/A

## Translations
N/A
